### PR TITLE
ci: add cross-model AI review (advisory)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,26 @@
+# Cross-model AI review — fleet caller.
+#
+# This thin workflow delegates to the reusable reviewer in project-noemi/agents,
+# so the review logic lives in exactly one place and this file should almost
+# never change. Deployed by scripts/deploy-ai-review.sh; documented in
+# docs/examples/cross-model-review-setup.md (Fleet deployment).
+#
+# Requires only organization-level Actions VARIABLES (no secrets in this repo):
+#   GCP_WIF_PROVIDER, GCP_SERVICE_ACCOUNT, GOOGLE_CLOUD_PROJECT,
+#   INFISICAL_PROJECT_ID, INFISICAL_IDENTITY_ID
+#
+# The review is ADVISORY: it posts findings as a comment and never approves,
+# merges, or blocks. Do not add it to required status checks.
+name: AI Review (advisory)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    uses: project-noemi/agents/.github/workflows/ai-review.yml@develop
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write


### PR DESCRIPTION
Adds the cross-model AI reviewer as a thin caller of the reusable workflow in project-noemi/agents.

**Advisory only.** It posts three-gate findings (premise → framing → code) as a PR comment. It never approves, merges, or blocks, and it must not be added to required status checks.

Merging this PR is the consent step: it enables the reviewer for this repository. Configuration comes from organization-level Actions variables — this repo needs no secrets and no further setup.

The first run on this PR is expected to **halt** (carve-out): this file is `.github/workflows/ai-review.yml`. A halt comment from `noemi-reviewer-bot[bot]` is the wiring test.

Framework: project-noemi/agents `docs/AI_REVIEW_GOVERNANCE.md`.
