### PR TITLE
chore: AI review smoke test (safe to close)

### DIFF
--- a/.ai-review-canary
+++ b/.ai-review-canary
@@ -1,0 +1,1 @@
+Temporary smoke test of the fleet AI reviewer. Safe to close.


### PR DESCRIPTION
Temporary smoke test after the AI-review caller landed on `develop`.

Expected: comment from `noemi-reviewer-bot[bot]` using a Pro preview model.
Safe to close unmerged.